### PR TITLE
Fix folder encoding issue in WebDAV

### DIFF
--- a/src/responses.ts
+++ b/src/responses.ts
@@ -41,7 +41,7 @@ export class Responses {
 							"D:prop": {
 								"D:getlastmodified": lastModified,
 								"D:lastmodified": lastModified,
-								"D:displayname": encodeURIComponent(resource.name),
+								"D:displayname": resource.name,
 								"D:getcontentlength": resource.type === "directory" ? 0 : resource.size,
 								"D:getetag": resource.uuid,
 								"D:creationdate": creationDate,


### PR DESCRIPTION
The D:displayname property should contain the raw, human-readable name according to WebDAV RFC 4918, not a URL-encoded string. Only D:href paths need to be URL encoded.

This fixes the issue where folder names with non-ASCII characters (like Chinese characters) were displayed as encoded strings (e.g., %E9%A2%84%E8%A7%88-115 instead of 预览-115).